### PR TITLE
issue #SB-23053 fix: disable all discussions tab

### DIFF
--- a/projects/discussion-ui/package.json
+++ b/projects/discussion-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@project-sunbird/discussions-ui-v8",
-  "version": "2.1.0-beta.3",
+  "version": "2.1.0-beta.4",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Sunbird-Ed/discussions-UI.git"

--- a/projects/discussion-ui/src/lib/common/constants.json
+++ b/projects/discussion-ui/src/lib/common/constants.json
@@ -594,7 +594,7 @@
     {
       "route": "all-discussions",
       "label": "All discussions",
-      "enable": true
+      "enable": false
     },
     {   
       "route": "categories",


### PR DESCRIPTION
To hide all discussion tab, by default it is set to false and Arun Kumar doing changes to make it configurable